### PR TITLE
16 fps and profiling with CPUTimeCounter.

### DIFF
--- a/application.cpp
+++ b/application.cpp
@@ -79,10 +79,10 @@ void Application::run()
     
     ui.lifecycle = UI::Ready;
     while (ui.lifecycle != UI::Quit) {
-        auto t1 = miosix::getTime();
+        //auto t1 = miosix::getTime();
         ui.update();
-        auto t2 = miosix::getTime();
-        iprintf("ui update = %lld\n",t2-t1);
+        //auto t2 = miosix::getTime();
+        //iprintf("ui update = %lld\n",t2-t1);
         Thread::sleep(80);
     }
     
@@ -168,13 +168,13 @@ void Application::processThreadMain()
         MLX90640RawFrame *rawFrame=nullptr;
         rawFrameQueue.get(rawFrame);
         if(rawFrame==nullptr) continue; //Happens on shutdown
-        auto t1=getTime();
+        //auto t1=getTime();
         auto *processedFrame=new MLX90640Frame;
         sensor->processFrame(rawFrame,processedFrame,ui.options.emissivity);
         delete rawFrame;
         processedFrameQueue.put(processedFrame);
-        auto t2=getTime();
-        iprintf("process = %lld\n",t2-t1);
+        //auto t2=getTime();
+        //iprintf("process = %lld\n",t2-t1);
     }
     iprintf("processThread min free stack %d\n",
             MemoryProfiling::getAbsoluteFreeStack());

--- a/application.cpp
+++ b/application.cpp
@@ -55,7 +55,7 @@ using namespace mxgui;
 
 Application::Application(Display& display)
     : display(display), ui(*this, display, ButtonState(1^up_btn::value(),on_btn::value())),
-      i2c(make_unique<I2C1Master>(sen_sda::getPin(),sen_scl::getPin(),400)),
+      i2c(make_unique<I2C1Master>(sen_sda::getPin(),sen_scl::getPin(),1000)),
       sensor(make_unique<MLX90640>(i2c.get()))
 {
     loadOptions(&ui.options,sizeof(ui.options));

--- a/applicationui.h
+++ b/applicationui.h
@@ -440,13 +440,13 @@ void ApplicationUI<IOHandler>::drawFrame(mxgui::DrawingContext& dc)
     lastFrameMutex.lock();
     if (lastFrame.get()!=nullptr)
     {
-        #ifdef _MIOSIX
+        #if 0 && defined(_MIOSIX)
         auto t1 = miosix::getTime();
         #endif
         bool smallCached=(state == Menu); //Cache now if the main thread changes it
         if(smallCached==false) renderer->render(lastFrame.get());
         else renderer->renderSmall(lastFrame.get());
-        #ifdef _MIOSIX
+        #if 0 && defined(_MIOSIX)
         auto t2 = miosix::getTime();
         #endif
         dc.setTextColor(std::make_pair(mxgui::white,mxgui::black));
@@ -472,7 +472,7 @@ void ApplicationUI<IOHandler>::drawFrame(mxgui::DrawingContext& dc)
             drawTemperature(dc,mxgui::Point(96,25),mxgui::Point(112,33),smallFont,
                             renderer->minTemperature());
         }
-        #ifdef _MIOSIX
+        #if 0 && defined(_MIOSIX)
         auto t3 = miosix::getTime();
         iprintf("render = %lld draw = %lld\n",t2-t1,t3-t2);
         #endif

--- a/applicationui.h
+++ b/applicationui.h
@@ -403,7 +403,7 @@ void ApplicationUI<IOHandler>::updateMenu()
                 drawMenuEntry(dc, Emissivity);
                 break;
             case FrameRate: 
-                if(options.frameRate>=8) options.frameRate=1;
+                if(options.frameRate>=16) options.frameRate=1;
                 else options.frameRate*=2;
                 drawMenuEntry(dc, FrameRate);
                 break;
@@ -414,7 +414,7 @@ void ApplicationUI<IOHandler>::updateMenu()
                 enterMain();
                 return;
         }
-    } 
+    }
     else if(upBtn.getAutorepeatEvent())
     {
         int oldEntry = menuEntry;

--- a/config/Makefile.inc
+++ b/config/Makefile.inc
@@ -20,6 +20,7 @@
 #OPT_BOARD := stm32f407vg_stm32f4discovery
 #OPT_BOARD := stm32f207ig_stm3220g-eval
 #OPT_BOARD := stm32f207zg_ethboard_v2
+#OPT_BOARD := stm32f207zg_nucleo
 #OPT_BOARD := stm32f207ze_als_camboard
 #OPT_BOARD := stm32l151_als_mainboard
 #OPT_BOARD := stm32f407vg_bitsboard
@@ -52,6 +53,8 @@ OPT_BOARD := stm32f205_generic
 #OPT_BOARD := atsam4lc2aa_generic
 #OPT_BOARD := stm32f411ce_blackpill
 #OPT_BOARD := stm32l4r9zi_sensortile
+#OPT_BOARD := stm32f767zi_nucleo
+#OPT_BOARD := stm32f769ni_discovery
 
 ##
 ## Optimization flags, choose one.
@@ -101,7 +104,7 @@ ifeq ($(OPT_BOARD),stm32f103ze_stm3210e-eval)
     ##    The microcontroller must have an external memory interface.
     ## Warning! enable external ram if you use a linker script that requires it
     ## (see the XRAM flag below)
-    LINKER_SCRIPT_PATH := arch/cortexM3_stm32/stm32f103ze_stm3210e-eval/
+    LINKER_SCRIPT_PATH := arch/cortexM3_stm32f1/stm32f103ze_stm3210e-eval/
     #LINKER_SCRIPT := $(LINKER_SCRIPT_PATH)stm32_512k+64k_rom.ld
     #LINKER_SCRIPT := $(LINKER_SCRIPT_PATH)stm32_512k+64k_xram.ld
     LINKER_SCRIPT := $(LINKER_SCRIPT_PATH)stm32_512k+64k_all_in_xram.ld
@@ -135,7 +138,7 @@ ifeq ($(OPT_BOARD),stm32f103ve_mp3v2)
     ## 1) Code in FLASH, stack + heap in internal RAM (file *_rom.ld)
     ## 2) Code + stack + heap in internal RAM (file *_ram.ld)
     ## Note: this board relies on a bootloader for interrupt forwarding in ram
-    LINKER_SCRIPT_PATH := arch/cortexM3_stm32/stm32f103ve_mp3v2/
+    LINKER_SCRIPT_PATH := arch/cortexM3_stm32f1/stm32f103ve_mp3v2/
     LINKER_SCRIPT := $(LINKER_SCRIPT_PATH)stm32_512k+64k_rom.ld
     #LINKER_SCRIPT := $(LINKER_SCRIPT_PATH)stm32_512k+64k_ram.ld
 
@@ -243,6 +246,12 @@ ifeq ($(OPT_BOARD),stm32f207zg_ethboard_v2)
     XRAM := -D__CODE_IN_XRAM
 
 endif
+
+##---------------------------------------------------------------------------
+## stm32f207zg_nucleo
+##
+
+# No options
 
 ##---------------------------------------------------------------------------
 ## stm32f205rg_sony-newman
@@ -520,7 +529,7 @@ endif
 ifeq ($(OPT_BOARD),stm32f103cx_generic)
     
     # stm32f103c8 has 64K, stm32f103cb has 128K
-    LINKER_SCRIPT_PATH := arch/cortexM3_stm32/stm32f103cx_generic/
+    LINKER_SCRIPT_PATH := arch/cortexM3_stm32f1/stm32f103cx_generic/
     #LINKER_SCRIPT := $(LINKER_SCRIPT_PATH)stm32_64k+20k_rom.ld
     LINKER_SCRIPT := $(LINKER_SCRIPT_PATH)stm32_128k+20k_rom.ld
     
@@ -546,7 +555,7 @@ endif
 ifeq ($(OPT_BOARD),stm32f100cx_generic)
 
     # stm32f100c8 has 64K, stm32f100cb has 128K
-    LINKER_SCRIPT_PATH := arch/cortexM3_stm32/stm32f100cx_generic/
+    LINKER_SCRIPT_PATH := arch/cortexM3_stm32f1/stm32f100cx_generic/
     #LINKER_SCRIPT := $(LINKER_SCRIPT_PATH)stm32_64k+8k_rom.ld
     LINKER_SCRIPT := $(LINKER_SCRIPT_PATH)stm32_128k+8k_rom.ld
 
@@ -659,20 +668,22 @@ endif
 ifeq ($(OPT_BOARD),lpc2138_miosix_board)
     ARCH := arm7_lpc2000
 else ifeq ($(OPT_BOARD),stm32f103ze_stm3210e-eval)
-    ARCH := cortexM3_stm32
+    ARCH := cortexM3_stm32f1
 else ifeq ($(OPT_BOARD),stm32f103ve_mp3v2)
-    ARCH := cortexM3_stm32
+    ARCH := cortexM3_stm32f1
 else ifeq ($(OPT_BOARD),stm32f100rb_stm32vldiscovery)
-    ARCH := cortexM3_stm32
+    ARCH := cortexM3_stm32f1
 else ifeq ($(OPT_BOARD),stm32f103ve_strive_mini)
-    ARCH := cortexM3_stm32
+    ARCH := cortexM3_stm32f1
 else ifeq ($(OPT_BOARD),stm32f103ze_redbull_v2)
-    ARCH := cortexM3_stm32
+    ARCH := cortexM3_stm32f1
 else ifeq ($(OPT_BOARD),stm32f407vg_stm32f4discovery)
     ARCH := cortexM4_stm32f4
 else ifeq ($(OPT_BOARD),stm32f207ig_stm3220g-eval)
     ARCH := cortexM3_stm32f2
 else ifeq ($(OPT_BOARD),stm32f207zg_ethboard_v2)
+    ARCH := cortexM3_stm32f2
+else ifeq ($(OPT_BOARD),stm32f207zg_nucleo)
     ARCH := cortexM3_stm32f2
 else ifeq ($(OPT_BOARD),stm32f207ze_als_camboard)
     ARCH := cortexM3_stm32f2
@@ -685,9 +696,9 @@ else ifeq ($(OPT_BOARD),stm32f407vg_bitsboard)
 else ifeq ($(OPT_BOARD),stm32f429zi_stm32f4discovery)
     ARCH := cortexM4_stm32f4
 else ifeq ($(OPT_BOARD),stm32f103cb_als_mainboard_rev2)
-    ARCH := cortexM3_stm32
+    ARCH := cortexM3_stm32f1
 else ifeq ($(OPT_BOARD),stm32f100cb_tempsensor)
-    ARCH := cortexM3_stm32
+    ARCH := cortexM3_stm32f1
 else ifeq ($(OPT_BOARD),stm32f429zi_oledboard2)
     ARCH := cortexM4_stm32f4
 else ifeq ($(OPT_BOARD),efm32gg332f1024_wandstem)
@@ -697,15 +708,15 @@ else ifeq ($(OPT_BOARD),stm32f411re_nucleo)
 else ifeq ($(OPT_BOARD),stm32f429zi_skyward_anakin)
     ARCH := cortexM4_stm32f4
 else ifeq ($(OPT_BOARD),stm32f100rc_solertegiard)
-    ARCH := cortexM3_stm32
+    ARCH := cortexM3_stm32f1
 else ifeq ($(OPT_BOARD),stm32f205rc_skyward_stormtrooper)
     ARCH := cortexM3_stm32f2
 else ifeq ($(OPT_BOARD),stm32f401vc_stm32f4discovery)
     ARCH := cortexM4_stm32f4
 else ifeq ($(OPT_BOARD),stm32f103c8_breakout)
-    ARCH := cortexM3_stm32
+    ARCH := cortexM3_stm32f1
 else ifeq ($(OPT_BOARD),stm32f100c8_microboard)
-    ARCH := cortexM3_stm32
+    ARCH := cortexM3_stm32f1
 else ifeq ($(OPT_BOARD),stm32f469ni_stm32f469i-disco)
     ARCH := cortexM4_stm32f4
 else ifeq ($(OPT_BOARD),stm32f429zi_skyward_homeone)
@@ -721,15 +732,15 @@ else ifeq ($(OPT_BOARD),stm32f407vg_thermal_test_chip)
 else ifeq ($(OPT_BOARD),stm32f205_generic)
     ARCH := cortexM3_stm32f2
 else ifeq ($(OPT_BOARD),stm32f103cx_generic)
-    ARCH := cortexM3_stm32
+    ARCH := cortexM3_stm32f1
 else ifeq ($(OPT_BOARD),stm32f072rb_stm32f0discovery)
     ARCH := cortexM0_stm32f0
 else ifeq ($(OPT_BOARD),stm32f100cx_generic)
-    ARCH := cortexM3_stm32
+    ARCH := cortexM3_stm32f1
 else ifeq ($(OPT_BOARD),stm32f303vc_stm32f3discovery)
     ARCH := cortexM4_stm32f3
 else ifeq ($(OPT_BOARD),stm32f100c8_vaisala_rs41)
-    ARCH := cortexM3_stm32
+    ARCH := cortexM3_stm32f1
 else ifeq ($(OPT_BOARD),stm32l476rg_nucleo)
     ARCH := cortexM4_stm32l4
 else ifeq ($(OPT_BOARD),atsam4lc2aa_generic)
@@ -738,6 +749,10 @@ else ifeq ($(OPT_BOARD),stm32f411ce_blackpill)
     ARCH := cortexM4_stm32f4
 else ifeq ($(OPT_BOARD),stm32l4r9zi_sensortile)
     ARCH := cortexM4_stm32l4
+else ifeq ($(OPT_BOARD),stm32f767zi_nucleo)
+    ARCH := cortexM7_stm32f7
+else ifeq ($(OPT_BOARD),stm32f769ni_discovery)
+    ARCH := cortexM7_stm32f7
 else
     $(info Error: no board specified in miosix/config/Makefile.inc)
     $(error Error)
@@ -832,11 +847,11 @@ ifeq ($(ARCH),arm7_lpc2000)
     PROGRAM_CMDLINE := lpc21isp -verify main.hex /dev/ttyUSB0 115200 14746
 
 ##-----------------------------------------------------------------------------
-## ARCHITECTURE: cortexM3_stm32
+## ARCHITECTURE: cortexM3_stm32f1
 ##
-else ifeq ($(ARCH),cortexM3_stm32)
+else ifeq ($(ARCH),cortexM3_stm32f1)
     ## Base directory with header files for this board
-    ARCH_INC := arch/cortexM3_stm32/common
+    ARCH_INC := arch/cortexM3_stm32f1/common
 
     ##-------------------------------------------------------------------------
     ## BOARD: stm32f103ze_stm3210e-eval
@@ -844,7 +859,7 @@ else ifeq ($(ARCH),cortexM3_stm32)
     ifeq ($(OPT_BOARD),stm32f103ze_stm3210e-eval)
 
         ## Base directory with header files for this board
-        BOARD_INC := arch/cortexM3_stm32/stm32f103ze_stm3210e-eval
+        BOARD_INC := arch/cortexM3_stm32f1/stm32f103ze_stm3210e-eval
 
         ## Select linker script and boot file
         ## Their path must be relative to the miosix directory.
@@ -880,7 +895,7 @@ else ifeq ($(ARCH),cortexM3_stm32)
     else ifeq ($(OPT_BOARD),stm32f103ve_mp3v2)
 
         ## Base directory with header files for this board
-        BOARD_INC := arch/cortexM3_stm32/stm32f103ve_mp3v2
+        BOARD_INC := arch/cortexM3_stm32f1/stm32f103ve_mp3v2
 
         ## Select linker script and boot file
         ## Their path must be relative to the miosix directory.
@@ -918,7 +933,7 @@ else ifeq ($(ARCH),cortexM3_stm32)
     else ifeq ($(OPT_BOARD),stm32f100rb_stm32vldiscovery)
 
         ## Base directory with header files for this board
-        BOARD_INC := arch/cortexM3_stm32/stm32f100rb_stm32vldiscovery
+        BOARD_INC := arch/cortexM3_stm32f1/stm32f100rb_stm32vldiscovery
 
         ## Select linker script and boot file
         ## Their path must be relative to the miosix directory.
@@ -954,7 +969,7 @@ else ifeq ($(ARCH),cortexM3_stm32)
     else ifeq ($(OPT_BOARD),stm32f100rc_solertegiard)
 
         ## Base directory with header files for this board
-        BOARD_INC := arch/cortexM3_stm32/stm32f100rc_solertegiard
+        BOARD_INC := arch/cortexM3_stm32f1/stm32f100rc_solertegiard
 
         ## Select linker script and boot file
         ## Their path must be relative to the miosix directory.
@@ -990,7 +1005,7 @@ else ifeq ($(ARCH),cortexM3_stm32)
     else ifeq ($(OPT_BOARD),stm32f103ve_strive_mini)
 
         ## Base directory with header files for this board
-        BOARD_INC := arch/cortexM3_stm32/stm32f103ve_strive_mini
+        BOARD_INC := arch/cortexM3_stm32f1/stm32f103ve_strive_mini
 
         ## Select linker script and boot file
         ## Their path must be relative to the miosix directory.
@@ -1024,7 +1039,7 @@ else ifeq ($(ARCH),cortexM3_stm32)
     ##
     else ifeq ($(OPT_BOARD),stm32f103ze_redbull_v2)
         ## Base directory with header files for this board
-        BOARD_INC := arch/cortexM3_stm32/stm32f103ze_redbull_v2
+        BOARD_INC := arch/cortexM3_stm32f1/stm32f103ze_redbull_v2
 
         ## Select linker script and boot file
         ## Their path must be relative to the miosix directory.
@@ -1060,7 +1075,7 @@ else ifeq ($(ARCH),cortexM3_stm32)
     ##
     else ifeq ($(OPT_BOARD),stm32f103cb_als_mainboard_rev2)
         ## Base directory with header files for this board
-        BOARD_INC := arch/cortexM3_stm32/stm32f103cb_als_mainboard_rev2
+        BOARD_INC := arch/cortexM3_stm32f1/stm32f103cb_als_mainboard_rev2
 
         ## Select linker script and boot file
         ## Their path must be relative to the miosix directory.
@@ -1094,7 +1109,7 @@ else ifeq ($(ARCH),cortexM3_stm32)
     else ifeq ($(OPT_BOARD),stm32f100cb_tempsensor)
 
         ## Base directory with header files for this board
-        BOARD_INC := arch/cortexM3_stm32/stm32f100cb_tempsensor
+        BOARD_INC := arch/cortexM3_stm32f1/stm32f100cb_tempsensor
 
         ## Select linker script and boot file
         ## Their path must be relative to the miosix directory.
@@ -1128,7 +1143,7 @@ else ifeq ($(ARCH),cortexM3_stm32)
     else ifeq ($(OPT_BOARD),stm32f103c8_breakout)
 
         ## Base directory with header files for this board
-        BOARD_INC := arch/cortexM3_stm32/stm32f103c8_breakout
+        BOARD_INC := arch/cortexM3_stm32f1/stm32f103c8_breakout
 
         ## Select linker script and boot file
         ## Their path must be relative to the miosix directory.
@@ -1160,7 +1175,7 @@ else ifeq ($(ARCH),cortexM3_stm32)
     else ifeq ($(OPT_BOARD),stm32f100c8_microboard)
 
         ## Base directory with header files for this board
-        BOARD_INC := arch/cortexM3_stm32/stm32f100c8_microboard
+        BOARD_INC := arch/cortexM3_stm32f1/stm32f100c8_microboard
 
         ## Select linker script and boot file
         ## Their path must be relative to the miosix directory.
@@ -1195,7 +1210,7 @@ else ifeq ($(ARCH),cortexM3_stm32)
     else ifeq ($(OPT_BOARD),stm32f103cx_generic)
 
         ## Base directory with header files for this board
-        BOARD_INC := arch/cortexM3_stm32/stm32f103cx_generic
+        BOARD_INC := arch/cortexM3_stm32f1/stm32f103cx_generic
 
         ## Select linker script and boot file
         ## Their path must be relative to the miosix directory.
@@ -1226,7 +1241,7 @@ else ifeq ($(ARCH),cortexM3_stm32)
     else ifeq ($(OPT_BOARD),stm32f100cx_generic)
 
         ## Base directory with header files for this board
-        BOARD_INC := arch/cortexM3_stm32/stm32f100cx_generic
+        BOARD_INC := arch/cortexM3_stm32f1/stm32f100cx_generic
 
         ## Select linker script and boot file
         ## Their path must be relative to the miosix directory.
@@ -1257,7 +1272,7 @@ else ifeq ($(ARCH),cortexM3_stm32)
     else ifeq ($(OPT_BOARD),stm32f100c8_vaisala_rs41)
 
         ## Base directory with header files for this board
-        BOARD_INC := arch/cortexM3_stm32/stm32f100c8_vaisala_rs41
+        BOARD_INC := arch/cortexM3_stm32f1/stm32f100c8_vaisala_rs41
 
         ## Select linker script and boot file
         ## Their path must be relative to the miosix directory.
@@ -1301,9 +1316,9 @@ else ifeq ($(ARCH),cortexM3_stm32)
 
     ## Select appropriate compiler flags for both ASM/C/C++/linker
     AFLAGS_BASE   := -mcpu=cortex-m3 -mthumb
-    CFLAGS_BASE   += -D_ARCH_CORTEXM3_STM32 $(CLOCK_FREQ) $(XRAM)            \
+    CFLAGS_BASE   += -D_ARCH_CORTEXM3_STM32F1 $(CLOCK_FREQ) $(XRAM)          \
                      -mcpu=cortex-m3 -mthumb $(OPT_OPTIMIZATION) -c 
-    CXXFLAGS_BASE += -D_ARCH_CORTEXM3_STM32 $(CLOCK_FREQ) $(XRAM)            \
+    CXXFLAGS_BASE += -D_ARCH_CORTEXM3_STM32F1 $(CLOCK_FREQ) $(XRAM)          \
                      $(OPT_EXCEPT) -mcpu=cortex-m3 -mthumb                   \
                      $(OPT_OPTIMIZATION) -c
     LFLAGS_BASE   := -mcpu=cortex-m3 -mthumb -Wl,--gc-sections,-Map,main.map \
@@ -1762,7 +1777,7 @@ else ifeq ($(ARCH),cortexM4_stm32f4)
     $(ARCH_INC)/interfaces-impl/portability.cpp              \
     $(ARCH_INC)/interfaces-impl/delays.cpp                   \
     $(ARCH_INC)/interfaces-impl/gpio_impl.cpp                \
-    arch/common/drivers/sd_stm32f2_f4.cpp                    \
+    arch/common/drivers/sd_stm32f2_f4_f7.cpp                 \
     arch/common/core/stm32f2_f4_l4_f7_h7_os_timer.cpp        \
     arch/common/CMSIS/Device/ST/STM32F4xx/Source/Templates/system_stm32f4xx.c
 
@@ -1788,7 +1803,7 @@ else ifeq ($(ARCH),cortexM3_stm32f2)
         ## Select architecture specific files
         ## These are the files in arch/<arch name>/<board name>
         ARCH_SRC :=                                  \
-        arch/common/drivers/sd_stm32f2_f4.cpp        \
+        arch/common/drivers/sd_stm32f2_f4_f7.cpp     \
         $(BOARD_INC)/interfaces-impl/delays.cpp      \
         $(BOARD_INC)/interfaces-impl/bsp.cpp
 
@@ -1827,7 +1842,7 @@ else ifeq ($(ARCH),cortexM3_stm32f2)
         ## Select architecture specific files
         ## These are the files in arch/<arch name>/<board name>
         ARCH_SRC :=                                  \
-        arch/common/drivers/sd_stm32f2_f4.cpp        \
+        arch/common/drivers/sd_stm32f2_f4_f7.cpp     \
         $(BOARD_INC)/interfaces-impl/delays.cpp      \
         $(BOARD_INC)/interfaces-impl/bsp.cpp
 
@@ -1853,6 +1868,42 @@ else ifeq ($(ARCH),cortexM3_stm32f2)
         else
         PROGRAM_CMDLINE := stm32flash -w main.hex -v /dev/ttyUSB1
         endif
+
+    ##-------------------------------------------------------------------------
+    ## BOARD: stm32f207zg_nucleo
+    ##
+    else ifeq ($(OPT_BOARD),stm32f207zg_nucleo)
+        ## Base directory with header files for this board
+        BOARD_INC := arch/cortexM3_stm32f2/stm32f207zg_nucleo
+
+        ## Select linker script and boot file
+        ## Their path must be relative to the miosix directory.
+        BOOT_FILE := $(BOARD_INC)/core/stage_1_boot.o
+        LINKER_SCRIPT := $(BOARD_INC)/stm32_1m+128k_rom.ld
+
+        ## Select architecture specific files
+        ## These are the files in arch/<arch name>/<board name>
+        ARCH_SRC :=                                  \
+        arch/common/drivers/sd_stm32f2_f4_f7.cpp     \
+        $(BOARD_INC)/interfaces-impl/delays.cpp      \
+        $(BOARD_INC)/interfaces-impl/bsp.cpp
+
+        ## Add a #define to allow querying board name
+        CFLAGS_BASE   += -D_BOARD_STM32F207ZG_NUCLEO
+        CXXFLAGS_BASE += -D_BOARD_STM32F207ZG_NUCLEO
+
+        ## Clock frequency
+        ## External clock is 8Mhz provided from MCO output of ST-LINK. Actual
+        ## HSE crystal (X3) is not fitted.
+        CLOCK_FREQ := -DHSE_VALUE=8000000 -DSYSCLK_FREQ_120MHz=120000000
+
+        ## Select programmer command line
+        ## This is the program that is invoked when the user types
+        ## 'make program'
+        ## The command must provide a way to program the board, or print an
+        ## error message saying that 'make program' is not supported for that
+        ## board.
+        PROGRAM_CMDLINE := st-flash --reset write "main.bin" 0x8000000
 
     ##-------------------------------------------------------------------------
     ## BOARD: stm32f207ze_als_camboard
@@ -1969,7 +2020,7 @@ else ifeq ($(ARCH),cortexM3_stm32f2)
         ## Select architecture specific files
         ## These are the files in arch/<arch name>/<board name>
         ARCH_SRC :=                                  \
-        arch/common/drivers/sd_stm32f2_f4.cpp        \
+        arch/common/drivers/sd_stm32f2_f4_f7.cpp     \
         arch/common/drivers/stm32f2_f4_i2c.cpp       \
         arch/common/drivers/servo_stm32.cpp          \
         $(BOARD_INC)/interfaces-impl/delays.cpp      \
@@ -2224,7 +2275,7 @@ else ifeq ($(ARCH),cortexM7_stm32f7)
         ## Select linker script and boot file
         ## Their path must be relative to the miosix directory.
         BOOT_FILE := $(BOARD_INC)/core/stage_1_boot.o
-        LINKER_SCRIPT := $(BOARD_INC)/stm32_1024k+256k_rom.ld
+        LINKER_SCRIPT := $(BOARD_INC)/stm32_1m+256k_rom.ld
 
         ## Select architecture specific files
         ## These are the files in arch/<arch name>/<board name>
@@ -2246,6 +2297,81 @@ else ifeq ($(ARCH),cortexM7_stm32f7)
         ## error message saying that 'make program' is not supported for that
         ## board.
         PROGRAM_CMDLINE := echo 'make program not supported.'
+
+    ##-------------------------------------------------------------------------
+    ## BOARD: stm32f767zi_nucleo
+    ##
+    else ifeq ($(OPT_BOARD),stm32f767zi_nucleo)
+        ## Select appropriate compiler flags for both ASM/C/C++/linker
+        ## The stm32f767 has the double precision FPU, so we will build for m7
+        ARCHOPTS := -mcpu=cortex-m7 -mthumb -mfloat-abi=hard -mfpu=fpv5-d16
+    
+        ## Base directory with header files for this board
+        BOARD_INC := arch/cortexM7_stm32f7/stm32f767zi_nucleo
+
+        ## Select linker script and boot file
+        ## Their path must be relative to the miosix directory.
+        BOOT_FILE := $(BOARD_INC)/core/stage_1_boot.o
+        LINKER_SCRIPT := $(BOARD_INC)/stm32_2m+384k_ram.ld
+
+        ## Select architecture specific files
+        ## These are the files in arch/<arch name>/<board name>
+        ARCH_SRC :=                           \
+        $(BOARD_INC)/interfaces-impl/bsp.cpp
+
+        ## Add a #define to allow querying board name
+        CFLAGS_BASE   += -D_BOARD_STM32F767ZI_NUCLEO
+        CXXFLAGS_BASE += -D_BOARD_STM32F767ZI_NUCLEO
+
+        ## Select clock frequency (HSE_VALUE is the xtal on board, fixed)
+        CLOCK_FREQ := -DHSE_VALUE=8000000 -DSYSCLK_FREQ_216MHz=216000000
+
+        ## Select programmer command line
+        ## This is the program that is invoked when the user types
+        ## 'make program'
+        ## The command must provide a way to program the board, or print an
+        ## error message saying that 'make program' is not supported for that
+        ## board.
+        PROGRAM_CMDLINE := st-flash --reset write "main.bin" 0x8000000
+
+    ##-------------------------------------------------------------------------
+    ## BOARD: stm32f769ni_discovery
+    ##
+    else ifeq ($(OPT_BOARD),stm32f769ni_discovery)
+        ## Select appropriate compiler flags for both ASM/C/C++/linker
+        ## The stm32f769 has the double precision FPU, so we will build for m7
+        ARCHOPTS := -mcpu=cortex-m7 -mthumb -mfloat-abi=hard -mfpu=fpv5-d16
+    
+        ## Base directory with header files for this board
+        BOARD_INC := arch/cortexM7_stm32f7/stm32f769ni_discovery
+
+        ## Select linker script and boot file
+        ## Their path must be relative to the miosix directory.
+        BOOT_FILE := $(BOARD_INC)/core/stage_1_boot.o
+        # LINKER_SCRIPT := $(BOARD_INC)/stm32_s2m+384k_ram.ld
+        LINKER_SCRIPT := $(BOARD_INC)/stm32_2m+16m_xram.ld
+
+        ## Select architecture specific files
+        ## These are the files in arch/<arch name>/<board name>
+        ARCH_SRC := $(BOARD_INC)/interfaces-impl/bsp.cpp
+
+        ## Add a #define to allow querying board name
+        CFLAGS_BASE   += -D_BOARD_STM32F769NI_DISCO
+        CXXFLAGS_BASE += -D_BOARD_STM32F769NI_DISCO
+
+        ## Enables the initialization of the external 16MB SDRAM memory
+        XRAM := -D__ENABLE_XRAM
+
+        ## Select clock frequency (HSE_VALUE is the xtal on board, fixed)
+        CLOCK_FREQ := -DHSE_VALUE=25000000 -DSYSCLK_FREQ_216MHz=216000000
+
+        ## Select programmer command line
+        ## This is the program that is invoked when the user types
+        ## 'make program'
+        ## The command must provide a way to program the board, or print an
+        ## error message saying that 'make program' is not supported for that
+        ## board.
+        PROGRAM_CMDLINE := st-flash --reset write "main.bin" 0x8000000
 
     ##-------------------------------------------------------------------------
     ## End of board list
@@ -2281,14 +2407,14 @@ else ifeq ($(ARCH),cortexM7_stm32f7)
     arch/common/core/mpu_cortexMx.cpp                        \
     arch/common/core/cache_cortexMx.cpp                      \
     arch/common/drivers/serial_stm32.cpp                     \
-    arch/common/drivers/sd_stm32f2_f4.cpp                    \
+    arch/common/drivers/sd_stm32f2_f4_f7.cpp                 \
     arch/common/drivers/dcc.cpp                              \
     $(ARCH_INC)/interfaces-impl/portability.cpp              \
     $(ARCH_INC)/interfaces-impl/delays.cpp                   \
     $(ARCH_INC)/interfaces-impl/gpio_impl.cpp                \
     arch/common/core/stm32f2_f4_l4_f7_h7_os_timer.cpp        \
     arch/common/CMSIS/Device/ST/STM32F7xx/Source/Templates/system_stm32f7xx.c
-    
+
 ##-----------------------------------------------------------------------------
 ## ARCHITECTURE: cortexM7_stm32h7
 ##
@@ -2379,14 +2505,14 @@ else ifeq ($(ARCH),cortexM7_stm32h7)
 ##
 else ifeq ($(ARCH),cortexM0_stm32f0)
     ## Base directory with else header files for this board
-    ARCH_INC := arch/cortexM0_stm32/common
+    ARCH_INC := arch/cortexM0_stm32f0/common
 
     ##-------------------------------------------------------------------------
     ## BOARD: stm32f072rb_stm32f0discovery
     ##
     ifeq ($(OPT_BOARD),stm32f072rb_stm32f0discovery)
         ## Base directory with header files for this board
-        BOARD_INC := arch/cortexM0_stm32/stm32f072rb_stm32f0discovery
+        BOARD_INC := arch/cortexM0_stm32f0/stm32f072rb_stm32f0discovery
 
         ## Select linker script and boot file
         ## Their path must be relative to the miosix directory.
@@ -2433,9 +2559,9 @@ else ifeq ($(ARCH),cortexM0_stm32f0)
 
     ## Select appropriate compiler flags for both ASM/C/C++/linker
     AFLAGS_BASE   := -mcpu=cortex-m0 -mthumb
-    CFLAGS_BASE   += -D_ARCH_CORTEXM0_STM32 $(CLOCK_FREQ) -mcpu=cortex-m0      \
+    CFLAGS_BASE   += -D_ARCH_CORTEXM0_STM32F0 $(CLOCK_FREQ) -mcpu=cortex-m0    \
                      -mthumb $(OPT_OPTIMIZATION) -c
-    CXXFLAGS_BASE += -D_ARCH_CORTEXM0_STM32 $(CLOCK_FREQ) -mcpu=cortex-m0      \
+    CXXFLAGS_BASE += -D_ARCH_CORTEXM0_STM32F0 $(CLOCK_FREQ) -mcpu=cortex-m0    \
                      -mthumb $(OPT_OPTIMIZATION) -c
     LFLAGS_BASE   := -mcpu=cortex-m0 -mthumb -Wl,--gc-sections,-Map,main.map   \
                      -Wl,-T$(KPATH)/$(LINKER_SCRIPT) $(OPT_EXCEPT)             \
@@ -2595,7 +2721,7 @@ else ifeq ($(ARCH),cortexM4_stm32l4)
         ## The command must provide a way to program the board, or print an
         ## error message saying that 'make program' is not supported for that
         ## board.
-        PROGRAM_CMDLINE := echo 'make program not supported.'
+        PROGRAM_CMDLINE := st-flash --reset write "main.bin" 0x8000000
 
     ##-------------------------------------------------------------------------
     ## End of board list

--- a/config/Makefile.inc
+++ b/config/Makefile.inc
@@ -63,7 +63,7 @@ OPT_BOARD := stm32f205_generic
 ## size and speed
 ##
 #OPT_OPTIMIZATION := -O0
-OPT_OPTIMIZATION := -O2
+OPT_OPTIMIZATION := -O2 -ffast-math
 #OPT_OPTIMIZATION := -O3
 #OPT_OPTIMIZATION := -Os
 

--- a/config/miosix_settings.h
+++ b/config/miosix_settings.h
@@ -80,7 +80,7 @@ namespace miosix {
 /// Allows to enable/disable CPUTimeCounter to save code size and remove its
 /// overhead from the scheduling process. By default it is defined
 /// (CPUTimeCounter is enabled).
-//#define WITH_CPU_TIME_COUNTER
+#define WITH_CPU_TIME_COUNTER
 
 //
 // Filesystem options

--- a/config/miosix_settings.h
+++ b/config/miosix_settings.h
@@ -76,6 +76,12 @@ namespace miosix {
 //#define SCHED_TYPE_CONTROL_BASED
 //#define SCHED_TYPE_EDF
 
+/// \def WITH_CPU_TIME_COUNTER
+/// Allows to enable/disable CPUTimeCounter to save code size and remove its
+/// overhead from the scheduling process. By default it is defined
+/// (CPUTimeCounter is enabled).
+//#define WITH_CPU_TIME_COUNTER
+
 //
 // Filesystem options
 //

--- a/drivers/MLX90640_API.cpp
+++ b/drivers/MLX90640_API.cpp
@@ -1310,37 +1310,37 @@ int ExtractDeviatingPixels(const uint16_t *eeData, paramsMLX90640 *mlx90640)
 
 //------------------------------------------------------------------------------
 
- int CheckAdjacentPixels(uint16_t pix1, uint16_t pix2)
- {
-     int pixPosDif;
-     
-     pixPosDif = pix1 - pix2;
-     if(pixPosDif > -34 && pixPosDif < -30)
-     {
-         return -6;
-     } 
-     if(pixPosDif > -2 && pixPosDif < 2)
-     {
-         return -6;
-     } 
-     if(pixPosDif > 30 && pixPosDif < 34)
-     {
-         return -6;
-     }
-     
-     return 0;    
- }
- 
- //------------------------------------------------------------------------------
- 
- int CheckEEPROMValid(const uint16_t *eeData)  
- {
-     int deviceSelect;
-     deviceSelect = eeData[10] & 0x0040;
-     if(deviceSelect == 0)
-     {
-         return 0;
-     }
-     
-     return -7;    
- }        
+int CheckAdjacentPixels(uint16_t pix1, uint16_t pix2)
+{
+    int pixPosDif;
+    
+    pixPosDif = pix1 - pix2;
+    if(pixPosDif > -34 && pixPosDif < -30)
+    {
+        return -6;
+    } 
+    if(pixPosDif > -2 && pixPosDif < 2)
+    {
+        return -6;
+    } 
+    if(pixPosDif > 30 && pixPosDif < 34)
+    {
+        return -6;
+    }
+    
+    return 0;    
+}
+
+//------------------------------------------------------------------------------
+
+int CheckEEPROMValid(const uint16_t *eeData)  
+{
+    int deviceSelect;
+    deviceSelect = eeData[10] & 0x0040;
+    if(deviceSelect == 0)
+    {
+        return 0;
+    }
+    
+    return -7;    
+}        

--- a/drivers/MLX90640_API.cpp
+++ b/drivers/MLX90640_API.cpp
@@ -42,10 +42,26 @@ int ExtractDeviatingPixels(const uint16_t *eeData, paramsMLX90640 *mlx90640);
 int CheckAdjacentPixels(uint16_t pix1, uint16_t pix2);
 int CheckEEPROMValid(const uint16_t *eeData);  
 
+inline float fast_rsqrtf(float number)
+{
+    union {
+        float    f;
+        uint32_t i;
+    } conv = { .f = number };
+    conv.i  = 0x5f3759df - (conv.i >> 1);
+    conv.f *= 1.5F - (number * 0.5F * conv.f * conv.f);
+    conv.f *= 1.5F - (number * 0.5F * conv.f * conv.f);
+    return conv.f;
+}
+
+inline float quadrtf(float number)
+{
+    return fast_rsqrtf(fast_rsqrtf(number));
+}
   
 int MLX90640_DumpEE(uint8_t slaveAddr, uint16_t *eeData)
 {
-     return MLX90640_I2CRead(slaveAddr, 0x2400, 832, eeData);
+    return MLX90640_I2CRead(slaveAddr, 0x2400, 832, eeData);
 }
 
 int MLX90640_GetFrameData(uint8_t slaveAddr, uint16_t *frameData)
@@ -375,9 +391,9 @@ void MLX90640_CalculateTo(const uint16_t *frameData, const paramsMLX90640 *param
             alphaCompensated = (params->alpha[pixelNumber] - params->tgc * params->cpAlpha[subPage])*(1 + params->KsTa * (ta - 25));
             
             Sx = powf(alphaCompensated, 3.f) * (irData + alphaCompensated * taTr);
-            Sx = sqrtf(sqrtf(Sx)) * params->ksTo[1];
+            Sx = quadrtf(Sx) * params->ksTo[1];
             
-            To = sqrtf(sqrtf(irData/(alphaCompensated * (1 - params->ksTo[1] * 273.15) + Sx) + taTr)) - 273.15;
+            To = quadrtf(irData/(alphaCompensated * (1 - params->ksTo[1] * 273.15) + Sx) + taTr) - 273.15;
                     
             if(To < params->ct[1])
             {
@@ -396,7 +412,7 @@ void MLX90640_CalculateTo(const uint16_t *frameData, const paramsMLX90640 *param
                 range = 3;            
             }      
             
-            To = sqrtf(sqrtf(irData / (alphaCompensated * alphaCorrR[range] * (1 + params->ksTo[range] * (To - params->ct[range]))) + taTr)) - 273.15;
+            To = quadrtf(irData / (alphaCompensated * alphaCorrR[range] * (1 + params->ksTo[range] * (To - params->ct[range]))) + taTr) - 273.15;
             
             result[pixelNumber] = To;
         }
@@ -508,9 +524,9 @@ void MLX90640_CalculateToShort(const uint16_t *frameData, const paramsMLX90640 *
             alphaCompensated = (params->alpha[pixelNumber] - params->tgc * params->cpAlpha[subPage])*(1 + params->KsTa * (ta - 25));
             
             Sx = powf(alphaCompensated, 3.f) * (irData + alphaCompensated * taTr);
-            Sx = sqrtf(sqrtf(Sx)) * params->ksTo[1];
+            Sx = quadrtf(Sx) * params->ksTo[1];
             
-            To = sqrtf(sqrtf(irData/(alphaCompensated * (1 - params->ksTo[1] * 273.15) + Sx) + taTr)) - 273.15;
+            To = quadrtf(irData/(alphaCompensated * (1 - params->ksTo[1] * 273.15) + Sx) + taTr) - 273.15;
                     
             if(To < params->ct[1])
             {
@@ -529,7 +545,7 @@ void MLX90640_CalculateToShort(const uint16_t *frameData, const paramsMLX90640 *
                 range = 3;            
             }      
             
-            To = sqrtf(sqrtf(irData / (alphaCompensated * alphaCorrR[range] * (1 + params->ksTo[range] * (To - params->ct[range]))) + taTr)) - 273.15;
+            To = quadrtf(irData / (alphaCompensated * alphaCorrR[range] * (1 + params->ksTo[range] * (To - params->ct[range]))) + taTr) - 273.15;
             
             //Clamp to -99..999°C multiplied by scaleFactor
             result[pixelNumber] = static_cast<short>(

--- a/drivers/MLX90640_API.h
+++ b/drivers/MLX90640_API.h
@@ -30,50 +30,50 @@
  */
 const int scaleFactor=4;
 
-    
-  typedef struct
-    {
-        int16_t kVdd;
-        int16_t vdd25;
-        float KvPTAT;
-        float KtPTAT;
-        uint16_t vPTAT25;
-        float alphaPTAT;
-        int16_t gainEE;
-        float tgc;
-        float cpKv;
-        float cpKta;
-        uint8_t resolutionEE;
-        uint8_t calibrationModeEE;
-        float KsTa;
-        float ksTo[4];
-        int16_t ct[4];
-        float alpha[768];    
-        int16_t offset[768];    
-        float kta[768];    
-        float kv[768];
-        float cpAlpha[2];
-        int16_t cpOffset[2];
-        float ilChessC[3]; 
-        uint16_t brokenPixels[5];
-        uint16_t outlierPixels[5];  
-    } paramsMLX90640;
-    
-    int MLX90640_DumpEE(uint8_t slaveAddr, uint16_t *eeData);
-    int MLX90640_GetFrameData(uint8_t slaveAddr, uint16_t *frameData);
-    int MLX90640_ExtractParameters(const uint16_t *eeData, paramsMLX90640 *mlx90640);
-    float MLX90640_GetVdd(const uint16_t *frameData, const paramsMLX90640 *params);
-    float MLX90640_GetTa(const uint16_t *frameData, const paramsMLX90640 *params, float vdd);
-    void MLX90640_GetImage(const uint16_t *frameData, const paramsMLX90640 *params, float *result);
-    void MLX90640_CalculateTo(const uint16_t *frameData, const paramsMLX90640 *params, float emissivity, float vdd, float ta, float tr, float *result);
-    void MLX90640_CalculateToShort(const uint16_t *frameData, const paramsMLX90640 *params, float emissivity, float vdd, float ta, float tr, short *result);
-    int MLX90640_SetResolution(uint8_t slaveAddr, uint8_t resolution);
-    int MLX90640_GetCurResolution(uint8_t slaveAddr);
-    int MLX90640_SetRefreshRate(uint8_t slaveAddr, uint8_t refreshRate);   
-    int MLX90640_GetRefreshRate(uint8_t slaveAddr);  
-    int MLX90640_GetSubPageNumber(const uint16_t *frameData);
-    int MLX90640_GetCurMode(uint8_t slaveAddr); 
-    int MLX90640_SetInterleavedMode(uint8_t slaveAddr);
-    int MLX90640_SetChessMode(uint8_t slaveAddr);
+
+typedef struct
+{
+    int16_t kVdd;
+    int16_t vdd25;
+    float KvPTAT;
+    float KtPTAT;
+    uint16_t vPTAT25;
+    float alphaPTAT;
+    int16_t gainEE;
+    float tgc;
+    float cpKv;
+    float cpKta;
+    uint8_t resolutionEE;
+    uint8_t calibrationModeEE;
+    float KsTa;
+    float ksTo[4];
+    int16_t ct[4];
+    float alpha[768];    
+    int16_t offset[768];    
+    float kta[768];    
+    float kv[768];
+    float cpAlpha[2];
+    int16_t cpOffset[2];
+    float ilChessC[3]; 
+    uint16_t brokenPixels[5];
+    uint16_t outlierPixels[5];  
+} paramsMLX90640;
+
+int MLX90640_DumpEE(uint8_t slaveAddr, uint16_t *eeData);
+int MLX90640_GetFrameData(uint8_t slaveAddr, uint16_t *frameData);
+int MLX90640_ExtractParameters(const uint16_t *eeData, paramsMLX90640 *mlx90640);
+float MLX90640_GetVdd(const uint16_t *frameData, const paramsMLX90640 *params);
+float MLX90640_GetTa(const uint16_t *frameData, const paramsMLX90640 *params, float vdd);
+void MLX90640_GetImage(const uint16_t *frameData, const paramsMLX90640 *params, float *result);
+void MLX90640_CalculateTo(const uint16_t *frameData, const paramsMLX90640 *params, float emissivity, float vdd, float ta, float tr, float *result);
+void MLX90640_CalculateToShort(const uint16_t *frameData, const paramsMLX90640 *params, float emissivity, float vdd, float ta, float tr, short *result);
+int MLX90640_SetResolution(uint8_t slaveAddr, uint8_t resolution);
+int MLX90640_GetCurResolution(uint8_t slaveAddr);
+int MLX90640_SetRefreshRate(uint8_t slaveAddr, uint8_t refreshRate);   
+int MLX90640_GetRefreshRate(uint8_t slaveAddr);  
+int MLX90640_GetSubPageNumber(const uint16_t *frameData);
+int MLX90640_GetCurMode(uint8_t slaveAddr); 
+int MLX90640_SetInterleavedMode(uint8_t slaveAddr);
+int MLX90640_SetChessMode(uint8_t slaveAddr);
     
 #endif

--- a/main.cpp
+++ b/main.cpp
@@ -26,6 +26,7 @@
  ***************************************************************************/
 
 #include <cstdio>
+#include "miosix.h"
 #include <drivers/misc.h>
 #include <application.h>
 #include <mxgui/display.h>
@@ -33,6 +34,7 @@
 
 using namespace std;
 using namespace mxgui;
+using namespace miosix;
 
 namespace mxgui {
 void registerDisplayHook(DisplayManager& dm)
@@ -41,9 +43,22 @@ void registerDisplayHook(DisplayManager& dm)
 }
 } //namespace mxgui
 
+#ifdef WITH_CPU_TIME_COUNTER
+void *profilerMain(void *)
+{
+    CPUProfiler::thread(5000000000LL);
+    return nullptr;
+}
+#endif
+
 int main()
 {
     initializeBoard();
+    
+    #ifdef WITH_CPU_TIME_COUNTER
+    Thread *profiler = Thread::create(profilerMain, 2048U, Priority(0), nullptr, 0);
+    #endif
+
     auto& display=DisplayManager::instance().getDisplay();
     
     try {
@@ -54,5 +69,8 @@ int main()
     }
     
     display.turnOff();
+    #ifdef WITH_CPU_TIME_COUNTER
+    profiler->terminate();
+    #endif
     shutdownBoard();
 }

--- a/renderer.h
+++ b/renderer.h
@@ -95,9 +95,12 @@ public:
 private:
     void doRender(MLX90640Frame *processedFrame, bool small);
 
-    static mxgui::Color interpolate2d(MLX90640Frame *processedFrame, int x, int y, short m, short r);
+    template<void (ThermalImageRenderer::*putPix)(int x, int y, mxgui::Color c)>
+    inline void renderLoop(MLX90640Frame *processedFrame, short range);
 
-    static mxgui::Color pixMap(short t, short m, short r);
+    static inline mxgui::Color interpolate2d(MLX90640Frame *processedFrame, int x, int y, short m, short r);
+
+    static inline mxgui::Color pixMap(short t, short m, short r);
 
     void crosshairPixel(int x, int y);
 
@@ -107,6 +110,19 @@ private:
     {
         if(a>0) return (a+b/2)/b;
         return (a-b/2)/b;
+    }
+
+    inline void putPixelLarge(int y, int x, mxgui::Color c)
+    {
+        irImage[2*y  ][2*x  ]=c; //Image layout in memory is reversed
+        irImage[2*y+1][2*x  ]=c;
+        irImage[2*y  ][2*x+1]=c;
+        irImage[2*y+1][2*x+1]=c;
+    }
+
+    inline void putPixelSmall(int y, int x, mxgui::Color c)
+    {
+        irImageSmall[y][x]=c; //Image layout in memory is reversed
     }
 
     union {


### PR DESCRIPTION
This PR replaces the previous profiling prints with CPUTimeCounter and implements optimizations that allow the sensor to reach 16 fps. Additionally, the PR fixes a bug in the display DMA code which caused an useless busy wait because DMA error interrupts were misinterpreted as end-of-transfer notifications.

The old profiling prints are kept in the code but commented, as they might become useful again in the future.